### PR TITLE
add_context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 go-journalctl*
+.idea

--- a/bin/cat.go
+++ b/bin/cat.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/Velocidex/go-journalctl/parser"
 	kingpin "github.com/alecthomas/kingpin/v2"
+	"github.com/rkirk-nos/go-journalctl/parser"
 	ntfs_parser "www.velocidex.com/golang/go-ntfs/parser"
 )
 

--- a/bin/cat.go
+++ b/bin/cat.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -87,7 +88,7 @@ func doCat() {
 }
 
 func PrintOnce(journal *parser.JournalFile) {
-	for log := range journal.GetLogs() {
+	for log := range journal.GetLogs(context.Background()) {
 		fmt.Printf("%v\n", log)
 	}
 }

--- a/bin/info.go
+++ b/bin/info.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Velocidex/go-journalctl/parser"
 	kingpin "github.com/alecthomas/kingpin/v2"
+	"github.com/rkirk-nos/go-journalctl/parser"
 	ntfs_parser "www.velocidex.com/golang/go-ntfs/parser"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Velocidex/go-journalctl
+module github.com/rkirk-nos/go-journalctl
 
 go 1.22.2
 

--- a/parser/open.go
+++ b/parser/open.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"errors"
 	"io"
 	"time"
@@ -35,7 +36,7 @@ func (self *JournalFile) GetLastSequence() uint64 {
 	return self.Header.tail_entry_seqnum()
 }
 
-func (self *JournalFile) GetLogs() chan *ordereddict.Dict {
+func (self *JournalFile) GetLogs(ctx context.Context) chan *ordereddict.Dict {
 	output_chan := make(chan *ordereddict.Dict)
 
 	var time_start, time_end int64
@@ -80,7 +81,12 @@ func (self *JournalFile) GetLogs() chan *ordereddict.Dict {
 						row = entry.GetParsed(self, obj_size)
 					}
 
-					output_chan <- row
+					select {
+					case <-ctx.Done():
+						return
+					case output_chan <- row:
+						// Sent log to channel
+					}
 				}
 
 				if self.MaxSeq > 0 && entry.seqnum() >= self.MaxSeq {

--- a/parser/watcher.go
+++ b/parser/watcher.go
@@ -48,7 +48,7 @@ func WatchFile(ctx context.Context,
 					journal.MaxSeq = last_seq
 					seq = int64(last_seq)
 
-					row_chan := journal.GetLogs()
+					row_chan := journal.GetLogs(context.Background())
 					for {
 						select {
 						case <-ctx.Done():


### PR DESCRIPTION
Add a context to `GetLogs` to allow caller to cancel without needing to read through the entire log file.

Tweaked package name & updated gitignore